### PR TITLE
refactoring and default name for joined files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ $phulp->task('js', function ($phulp) {
 
 ### Options
 
-***Join*** : When join flag is true all distFiles will be merged in
-one and the final file name will be a md5 hash. You can set this in
-the constructor, by default the join flag is false:
+Set in the constructor.
+
+***Join*** : When join flag is true all distFiles will be merged in one.
+
+***joinName*** : Name of the joined file.
 
 ```php
 <?php
@@ -46,7 +48,17 @@ the constructor, by default the join flag is false:
 use Phulp\Minifier\CssMinifier;
 use Phulp\Minifier\JsMinifier;
 
-$cssMinifier = new CssMinifier(['join' => true]); // the join flag is true
-$jsMinifier = new JsMinifier(['join' => true]); // the join flag is true
+$cssMinifier = new CssMinifier([
+    // default: false
+    'join' => true,
+    // default: styles.min.css
+    'joinName' => 'myMinifiedCss.css'
+]);
+$jsMinifier = new JsMinifier([
+    // default: false
+    'join' => true
+    // default: script.min.js
+    'joinName' => 'myMinifiedJs.js'
+]);
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ use Phulp\Minifier\JsMinifier;
 
 $phulp->task('css', function ($phulp) {
     $phulp->src(['src/'], '/css$/')
-        ->pipe(new CssMinifier);
+        // minify
+        ->pipe(new CssMinifier)
+        // write minified files
+        ->pipe($phulp->dest('dist/'));
 });
 
 $phulp->task('js', function ($phulp) {
     $phulp->src(['src/'], '/js$/')
-        ->pipe(new JsMinifier);
+        // minify
+        ->pipe(new JsMinifier)
+        // write minified files
+        ->pipe($phulp->dest('dist/'));
 });
 
 ```

--- a/src/CssMinifier.php
+++ b/src/CssMinifier.php
@@ -2,52 +2,23 @@
 
 namespace Phulp\Minifier;
 
-use Phulp\PipeInterface;
-use Phulp\Source;
-use Phulp\DistFile;
 use MatthiasMullie\Minify\CSS;
 
-class CssMinifier implements PipeInterface
+class CssMinifier extends MinifierAbstract 
 {
     /**
-     * @var array $options
+     * {@inheritdoc}
      */
-    private $options = [
+    protected $options = [
         'join' => false,
+        'joinName' => 'styles.min.css'
     ];
 
     /**
-     * @param array $options
+     * {@inheritdoc}
      */
-    public function __construct(array $options = [])
+    protected function createMinifier()
     {
-        $this->options = array_merge($this->options, $options);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function execute(Source $src)
-    {
-        $min = new CSS;
-        foreach ($src->getDistFiles() as $key => $file) {
-            if (preg_match('/css$/', $file->getName()) || preg_match('/css$/', $file->getDistpathname())) {
-                if (!$this->options['join']) {
-                    $min = new CSS;
-                }
-
-                $min->add($file->getContent());
-
-                if (!$this->options['join']) {
-                    $file->setContent($min->minify());
-                } else {
-                    $src->removeDistFile($key);
-                }
-            }
-        }
-
-        if ($this->options['join']) {
-            $src->addDistFile(new DistFile($min->minify(), md5(uniqid(microtime())) . '.css'));
-        }
+        return new CSS;
     }
 }

--- a/src/JsMinifier.php
+++ b/src/JsMinifier.php
@@ -2,52 +2,23 @@
 
 namespace Phulp\Minifier;
 
-use Phulp\PipeInterface;
-use Phulp\Source;
-use Phulp\DistFile;
 use MatthiasMullie\Minify\JS;
 
-class JsMinifier implements PipeInterface
+class JsMinifier extends MinifierAbstract 
 {
     /**
-     * @var array $options
+     * {@inheritdoc}
      */
-    private $options = [
+    protected $options = [
         'join' => false,
+        'joinName' => 'script.min.js'
     ];
 
     /**
-     * @param array $options
+     * {@inheritdoc}
      */
-    public function __construct(array $options = [])
+    protected function createMinifier()
     {
-        $this->options = array_merge($this->options, $options);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function execute(Source $src)
-    {
-        $min = new JS();
-        foreach ($src->getDistFiles() as $key => $file) {
-            if (preg_match('/js$/', $file->getName()) || preg_match('/js$/', $file->getDistpathname())) {
-                if (!$this->options['join']) {
-                    $min = new JS;
-                }
-
-                $min->add($file->getContent());
-
-                if (!$this->options['join']) {
-                    $file->setContent($min->minify());
-                } else {
-                    $src->removeDistFile($key);
-                }
-            }
-        }
-
-        if ($this->options['join']) {
-            $src->addDistFile(new DistFile($min->minify(), md5(uniqid(microtime())) . '.js'));
-        }
+        return new JS;
     }
 }

--- a/src/MinifierAbstract.php
+++ b/src/MinifierAbstract.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Phulp\Minifier;
+
+use Phulp\PipeInterface;
+use Phulp\Source;
+use Phulp\DistFile;
+
+abstract class MinifierAbstract implements PipeInterface
+{
+    /**
+     * @var array $options
+     */
+    protected $options =  [];
+    
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge($this->options, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(Source $src)
+    {
+        $join = $this->options['join'];
+        $min = $this->createMinifier();
+
+        foreach ($src->getDistFiles() as $key => $file) {
+            $min->add($file->getContent());
+
+            if ($join) {
+                $src->removeDistFile($key);
+            } else {
+                $file->setContent($min->minify());
+                $min = $this->createMinifier();
+            }
+        }
+
+        if ($join) {
+            $name = $this->options['joinName'];
+            $src->addDistFile(new DistFile($min->minify(), $name));
+        }
+    }
+
+    /**
+     * Creates new minifier instance
+     * 
+     * @return mixed
+     */
+    protected abstract function createMinifier();
+}


### PR DESCRIPTION
- Adds the "write files" command to readme.
- Introduces an abstract minifier class, which collects the nearly identical code for JS and CSS.
- Removes additional file extension check. This should be done by the user with the src filter.
- Adds a default name option for joined file. The assets are probably referenced/linked somewhere, creating random files isn't very useful.